### PR TITLE
Make compatible with Storm 1.0.0

### DIFF
--- a/src/jvm/com/nathanmarz/storm/scheme/StringScheme.java
+++ b/src/jvm/com/nathanmarz/storm/scheme/StringScheme.java
@@ -1,16 +1,18 @@
-package backtype.storm.scheme;
+package com.nathanmarz.storm.scheme;
 
-import backtype.storm.spout.Scheme;
-import backtype.storm.tuple.Fields;
-import backtype.storm.tuple.Values;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Values;
+
 import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class StringScheme implements Scheme {
 
-    public List<Object> deserialize(byte[] bytes) {
+    public List<Object> deserialize(ByteBuffer bytes) {
         try {
-            return new Values(new String(bytes, "UTF-8"));
+            return new Values(new String(bytes.array(), "UTF-8"));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/src/jvm/com/nathanmarz/storm/spout/KestrelThriftClient.java
+++ b/src/jvm/com/nathanmarz/storm/spout/KestrelThriftClient.java
@@ -1,17 +1,20 @@
-package backtype.storm.spout;
+package com.nathanmarz.storm.spout;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import net.lag.kestrel.thrift.*;
-import java.util.List;
-import java.util.Set;
+import net.lag.kestrel.thrift.Item;
+import net.lag.kestrel.thrift.Kestrel;
+import net.lag.kestrel.thrift.QueueInfo;
 import org.apache.thrift7.TException;
 import org.apache.thrift7.protocol.TBinaryProtocol;
 import org.apache.thrift7.protocol.TProtocol;
 import org.apache.thrift7.transport.TFramedTransport;
 import org.apache.thrift7.transport.TSocket;
 import org.apache.thrift7.transport.TTransport;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /* Thin wrapper around Thrift Client for Kestrel */
 public class KestrelThriftClient implements Kestrel.Iface {

--- a/src/jvm/com/nathanmarz/storm/spout/KestrelThriftSpout.java
+++ b/src/jvm/com/nathanmarz/storm/spout/KestrelThriftSpout.java
@@ -1,5 +1,21 @@
-package backtype.storm.spout;
+package com.nathanmarz.storm.spout;
 
+import net.lag.kestrel.thrift.Item;
+import org.apache.log4j.Logger;
+import org.apache.storm.Config;
+import org.apache.storm.spout.MultiScheme;
+import org.apache.storm.spout.RawMultiScheme;
+import org.apache.storm.spout.Scheme;
+import org.apache.storm.spout.SchemeAsMultiScheme;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichSpout;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.utils.Utils;
+import org.apache.thrift7.TException;
+
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -9,17 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 
-import net.lag.kestrel.thrift.Item;
-
-import org.apache.log4j.Logger;
-import org.apache.thrift7.TException;
-
-import backtype.storm.Config;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.base.BaseRichSpout;
-import backtype.storm.tuple.Fields;
-import backtype.storm.utils.Utils;
 
 
 /**
@@ -184,7 +189,7 @@ public class KestrelThriftSpout extends BaseRichSpout {
             HashSet toAck = new HashSet();
 
             for(Item item : items) {
-                Iterable<List<Object>> retItems = _scheme.deserialize(item.get_data());
+                Iterable<List<Object>> retItems = _scheme.deserialize(ByteBuffer.wrap(item.get_data()));
 
                 if (retItems != null) {
                     for(List<Object> retItem: retItems) {

--- a/src/jvm/com/nathanmarz/storm/spout/TestTopology.java
+++ b/src/jvm/com/nathanmarz/storm/spout/TestTopology.java
@@ -1,14 +1,15 @@
-package backtype.storm.spout;
+package com.nathanmarz.storm.spout;
 
-import backtype.storm.Config;
-import backtype.storm.LocalCluster;
-import backtype.storm.scheme.StringScheme;
-import backtype.storm.task.OutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.topology.base.BaseRichBolt;
-import backtype.storm.tuple.Tuple;
+import com.nathanmarz.storm.scheme.StringScheme;
+import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Tuple;
+
 import java.util.Map;
 
 


### PR DESCRIPTION
- Move classes to a new package indicative of original author, `com.nathanmarz`
- Update references to Storm classes from `backtype.storm` to `org.apache.storm`